### PR TITLE
Updated target frameworks and test dependencies.

### DIFF
--- a/RangedObservableCollection.Tests/RangedObservableCollection.Tests.csproj
+++ b/RangedObservableCollection.Tests/RangedObservableCollection.Tests.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+	<TargetFrameworks>net4.8.1;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.reporters" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.reporters" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RangedObservableCollection/RangedObservableCollection.csproj
+++ b/RangedObservableCollection/RangedObservableCollection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>System.Collections.ObjectModel</RootNamespace>
     <AssemblyName>System.Collections.ObjectModel.RangedObservableCollection</AssemblyName>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>


### PR DESCRIPTION
Updated target frameworks to get rid of unnecessary CVEs due to  .net standard 1.0 transitive package dependencies which includes known issues:

- System.Net.Http 4.3.0
- System.Private.Uri 4.3.0
- System.Text.RegularExpressions 4.3.0